### PR TITLE
Draft: Fix for debugger hang

### DIFF
--- a/Chutzpah/Chutzpah.csproj
+++ b/Chutzpah/Chutzpah.csproj
@@ -45,6 +45,7 @@
     <Reference Include="System">
       <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.8\System.dll</HintPath>
     </Reference>
+    <Reference Include="System.Management" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -395,7 +396,7 @@
       <Link>x64\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <InProject>false</InProject>
-    </None>    
+    </None>
     <None Include="$(MSBuildThisFileDirectory)..\packages\Libuv.1.10.0\runtimes\win-x86\native\*.dll">
       <Link>x86\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -414,7 +415,7 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.1</Version>
-    </PackageReference>	
+    </PackageReference>
     <PackageReference Include="ServiceStack">
       <Version>5.13.2</Version>
     </PackageReference>

--- a/Chutzpah/Models/PathInfo.cs
+++ b/Chutzpah/Models/PathInfo.cs
@@ -1,8 +1,11 @@
+using System.Diagnostics;
+
 namespace Chutzpah.Models
 {
     /// <summary>
     /// Contains information about a path like full path and type
     /// </summary>
+    [DebuggerDisplay("{FullPath}")]
     public class PathInfo
     {
         /// <summary>

--- a/Chutzpah/TestRunner.cs
+++ b/Chutzpah/TestRunner.cs
@@ -356,7 +356,7 @@ namespace Chutzpah
             // own context
             foreach (var group in fileSettingGroups)
             {
-                if (group.Key.EnableTestFileBatching.Value)
+                if (group.Key.EnableTestFileBatching == true)
                 {
                     testGroups.Add(group.ToList());
                 }

--- a/Chutzpah/Utility/ProcessExtensions.cs
+++ b/Chutzpah/Utility/ProcessExtensions.cs
@@ -1,8 +1,4 @@
-﻿//----------------------------------------------------
-// Copyright 2022 Epic Systems Corporation
-//----------------------------------------------------
-
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Linq;

--- a/Chutzpah/Utility/ProcessExtensions.cs
+++ b/Chutzpah/Utility/ProcessExtensions.cs
@@ -1,9 +1,14 @@
-﻿using System;
+﻿//----------------------------------------------------
+// Copyright 2022 Epic Systems Corporation
+//----------------------------------------------------
+
+using System;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Runtime.InteropServices;
+using System.Management;
 
 namespace Chutzpah.Utility
 {
@@ -59,10 +64,10 @@ namespace Chutzpah.Utility
              int processId);
         [DllImport("kernel32.dll")]
         static extern IntPtr OpenThread(
-            ThreadAccess dwDesiredAccess, 
-            bool bInheritHandle, 
+            ThreadAccess dwDesiredAccess,
+            bool bInheritHandle,
             uint dwThreadId);
-        [DllImport("kernel32.dll", SetLastError=true)]
+        [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         static extern bool CloseHandle(
             IntPtr hObject);
@@ -88,7 +93,8 @@ namespace Chutzpah.Utility
             foreach (ProcessThread thread in process.Threads)
             {
                 var pOpenThread = OpenThread(ThreadAccess.SUSPEND_RESUME, false, (uint)thread.Id);
-                if (pOpenThread != IntPtr.Zero) {
+                if (pOpenThread != IntPtr.Zero)
+                {
                     SuspendThread(pOpenThread);
                     CloseHandle(pOpenThread);
                 }
@@ -103,7 +109,8 @@ namespace Chutzpah.Utility
             foreach (ProcessThread thread in process.Threads)
             {
                 var pOpenThread = OpenThread(ThreadAccess.SUSPEND_RESUME, false, (uint)thread.Id);
-                if (pOpenThread != IntPtr.Zero) {
+                if (pOpenThread != IntPtr.Zero)
+                {
                     ResumeThread(pOpenThread);
                     CloseHandle(pOpenThread);
                 }
@@ -127,22 +134,53 @@ namespace Chutzpah.Utility
                     uint bytesWritten;
                     int ntStatus = NtQueryInformationProcess(
                         p.Handle,
-                        0, 
-                        ref processInfoB, 
+                        0,
+                        ref processInfoB,
                         (uint)Marshal.SizeOf(processInfoB),
                         out bytesWritten); // == 0 is OK
-                    if (0 != ntStatus) { // fail?
-                        continue; }
+                    if (0 != ntStatus)
+                    { // fail?
+                        continue;
+                    }
                     // Is it a child process of the subject process?
-                    if (processInfoB.InheritedFromUniqueProcessId == subjectProcessId) {
-                        return p; }
+                    if (processInfoB.InheritedFromUniqueProcessId == subjectProcessId)
+                    {
+                        return p;
+                    }
                 }
                 catch (Exception /* ex */)
                 {
                     // Ignore, most likely 'Access Denied'
                 }
             }
-            return null; 
+            return null;
+        }
+
+        /// <summary>
+        /// Locate the first child process for the specified process id.
+        /// </summary>
+        /// <param name="parentProcessId"></param>
+        /// <returns></returns>
+        public static Process FindFirstChildProcess(int parentProcessId)
+        {
+            //https://docs.microsoft.com/en-us/dotnet/api/system.management.managementobjectsearcher.get?view=dotnet-plat-ext-6.0
+            //https://social.msdn.microsoft.com/Forums/en-US/81c8137e-6868-4b95-bdf8-37624b7f0166/managementobjectsearcher-processes-win32process-access-denied?forum=csharplanguage
+            ManagementObjectSearcher searcher = new ManagementObjectSearcher("Select * From Win32_Process Where ParentProcessId = " + parentProcessId);
+            ManagementObjectCollection resultList = searcher.Get();
+
+            try
+            {
+                foreach (ManagementObject item in resultList)
+                {
+                    object value = item.GetPropertyValue("ProcessId");
+                    int childProcessId = Convert.ToInt32(value);
+                    return Process.GetProcessById(childProcessId);
+                }
+            }
+            catch { }
+
+            return null;
+
         }
 
         /// <summary>
@@ -150,42 +188,53 @@ namespace Chutzpah.Utility
         /// </summary>
         /// <param name="matchSame">Value to return if/when process ids are the same.</param>
         public static bool IsProcessAAncestorOfProcessB(
-            int processId_A, 
-            int processId_B, 
+            int processId_A,
+            int processId_B,
             bool matchSame = true,
             int maxHops = int.MaxValue)
         {
-            if (processId_A == processId_B) {
-                return matchSame; }
+            if (processId_A == processId_B)
+            {
+                return matchSame;
+            }
             // Get process handle from the process id.
             //Process pB = Process.GetProcessById(processId_B); // This throws if process not found, which is undesirable.
             var hProcess = OpenProcess(ProcessAccessFlags.QueryInformation, false, processId_B);
-            if (hProcess == IntPtr.Zero) {
-                return false; }
+            if (hProcess == IntPtr.Zero)
+            {
+                return false;
+            }
             // Get info about the process.
             PROCESS_BASIC_INFORMATION processInfoB = new PROCESS_BASIC_INFORMATION();
             uint bytesWritten;
             int ntStatus = NtQueryInformationProcess(
                 hProcess,
-                0, 
-                ref processInfoB, 
+                0,
+                ref processInfoB,
                 (uint)Marshal.SizeOf(processInfoB),
                 out bytesWritten); // == 0 is OK
             CloseHandle(hProcess);
-            if (0 != ntStatus) {
+            if (0 != ntStatus)
+            {
                 Debug.Assert(false);
-                return false; }
+                return false;
+            }
             // Does B directly inherit from A?
-            if (processInfoB.InheritedFromUniqueProcessId == processId_A) {
-                return true; }
+            if (processInfoB.InheritedFromUniqueProcessId == processId_A)
+            {
+                return true;
+            }
             // Optionally recurse up the hierarchy.
-            if (maxHops > 0) {
-                if (processInfoB.InheritedFromUniqueProcessId != 0) {
+            if (maxHops > 0)
+            {
+                if (processInfoB.InheritedFromUniqueProcessId != 0)
+                {
                     return IsProcessAAncestorOfProcessB(
-                        processId_A, 
-                        (int)processInfoB.InheritedFromUniqueProcessId, 
+                        processId_A,
+                        (int)processInfoB.InheritedFromUniqueProcessId,
                         matchSame,
-                        maxHops -1); }
+                        maxHops - 1);
+                }
             }
             // No match.
             return false;

--- a/VS.Common/VsDebuggerTestLauncher.cs
+++ b/VS.Common/VsDebuggerTestLauncher.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿//----------------------------------------------------
+// Copyright 2022 Epic Systems Corporation
+//----------------------------------------------------
+
+using System;
 using System.Diagnostics;
 using Chutzpah.Models;
 using Chutzpah.Utility;
@@ -27,27 +31,31 @@ namespace Chutzpah.VS.Common
                 UseShellExecute = true,
                 FileName = BrowserPathHelper.GetBrowserPath("ie"),
                 Arguments = string.Format("-noframemerging -suspended -debug {0}", file)
-                    // -noframemerging
-                    //      This is what VS does when launching the script debugger.
-                    //      Unsure whether strictly necessary.
-                    // -suspended
-                    //      This is what VS does when launching the script debugger.
-                    //      Seems to cause IE to suspend all threads which is what we want.
-                    // -debug
-                    //      This is what VS does when launching the script debugger.
-                    //      Not sure exactly what it does.
+                //Arguments = file
+                // -noframemerging
+                //      This is what VS does when launching the script debugger.
+                //      Unsure whether strictly necessary.
+                // -suspended
+                //      This is what VS does when launching the script debugger.
+                //      Seems to cause IE to suspend all threads which is what we want.
+                // -debug
+                //      This is what VS does when launching the script debugger.
+                //      Not sure exactly what it does.
             };
             Process ieMainProcess = Process.Start(startInfo);
 
-            int ieBrowserTabOpenTimeout = ((testContext.TestFileSettings.IEBrowserTabOpenTimeout ?? Constants.DefaultIEBrowserTabOpenTimeout) * 100);
+            //Wait for some time for the ie process to start
+            //System.Threading.Thread.Sleep(250);
+
+            int ieBrowserTabOpenTimeout = 10;   //We will try 10 times and not 400
 
             // Get child 'tab' process spawned by IE.
-            for (int i = 0;; ++i)
+            for (int i = 0; ; ++i)
             {
                 // We need to wait a few ms for IE to open the process.
                 System.Threading.Thread.Sleep(10);
 
-                this.DebuggingProcess = ProcessExtensions.FindFirstChildProcessOf(ieMainProcess.Id);
+                DebuggingProcess = ProcessExtensions.FindFirstChildProcess(ieMainProcess.Id);
                 if (this.DebuggingProcess != null)
                 {
                     break;
@@ -58,7 +66,7 @@ namespace Chutzpah.VS.Common
                     throw new InvalidOperationException("Timeout waiting for Internet Explorer child process to start.");
                 }
             }
-                           
+
             // Debug the script in that tab process.
             DteHelpers.DebugAttachToProcess(this.DebuggingProcess.Id, "script");
 

--- a/VS2022/source.extension.vsixmanifest
+++ b/VS2022/source.extension.vsixmanifest
@@ -1,42 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="0E655946-6443-4BCE-AABB-6466C14C6521" Version="4.4.12" Language="en-US" Publisher="Matthew Manela" />
-        <DisplayName>Chutzpah Test Adapter for the Test Explorer VS2022</DisplayName>
-        <Description xml:space="preserve">Chutzpah adapter for the Visual Studio Unit Test Explorer. Chutzpah is an open source JavaScript test runner which enables you to run JavaScript unit tests from the command line and from inside of Visual Studio.</Description>
-        <MoreInfo>https://github.com/mmanela/chutzpah</MoreInfo>
-        <License>EULA.rtf</License>
-        <GettingStartedGuide>https://github.com/mmanela/chutzpah</GettingStartedGuide>
-        <Icon>chetTimes.png</Icon>
-        <PreviewImage>chetTimes.png</PreviewImage>
-        <Tags>Javascript, Unit Testing, HTML, Visual Studio 2022, TDD, qunit, jasmine, testing, CoffeeScript, TypeScript</Tags>
-    </Metadata>
-    <Installation InstalledByMsi="false">
-        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
-            <ProductArchitecture>amd64</ProductArchitecture>
-        </InstallationTarget>
-        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
-            <ProductArchitecture>amd64</ProductArchitecture>
-        </InstallationTarget>
-        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
-            <ProductArchitecture>amd64</ProductArchitecture>
-        </InstallationTarget>
-        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.IntegratedShell">
-            <ProductArchitecture>amd64</ProductArchitecture>
-        </InstallationTarget>
-    </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-        <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0]" />
-    </Dependencies>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-        <Asset d:Source="Project" d:ProjectName="%CurrentProject%.TestAdapter" Type="Microsoft.VisualStudio.MefComponent" Path="|VS2022.TestAdapter|" />
-        <Asset Type="UnitTestExtension" d:Source="Project" d:ProjectName="%CurrentProject%.TestAdapter" Path="|VS2022.TestAdapter|" />
-        <Asset d:Source="Project" d:ProjectName="VS.Common" Type="Microsoft.VisualStudio.MefComponent" Path="|VS.Common|" />
-        <Asset d:Source="Project" d:ProjectName="%CurrentProject%" Type="Microsoft.VisualStudio.MefComponent" Path="|%CurrentProject%|" />
-    </Assets>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
+  <Metadata>
+    <Identity Id="0E655946-6443-4BCE-AABB-6466C14C6521" Version="4.4.12" Language="en-US" Publisher="Matthew Manela" />
+    <DisplayName>Chutzpah Test Explorer Adapter (VS2022)</DisplayName>
+    <Description>Chutzpah adapter for the Visual Studio Unit Test Explorer. Chutzpah is an open source JavaScript test runner which enables you to run JavaScript unit tests from the command line and from inside of Visual Studio.</Description>
+    <MoreInfo>https://github.com/mmanela/chutzpah</MoreInfo>
+    <License>EULA.rtf</License>
+    <GettingStartedGuide>https://github.com/mmanela/chutzpah</GettingStartedGuide>
+    <Icon>chetTimes.png</Icon>
+    <PreviewImage>chetTimes.png</PreviewImage>
+    <Tags>Javascript, Unit Testing, HTML, Visual Studio 2022, TDD, qunit, jasmine, testing, CoffeeScript, TypeScript</Tags>
+  </Metadata>
+  <Installation InstalledByMsi="false">
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.IntegratedShell">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0]" />
+  </Dependencies>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    <Asset d:Source="Project" d:ProjectName="%CurrentProject%.TestAdapter" Type="Microsoft.VisualStudio.MefComponent" Path="|VS2022.TestAdapter|" />
+    <Asset Type="UnitTestExtension" d:Source="Project" d:ProjectName="%CurrentProject%.TestAdapter" Path="|VS2022.TestAdapter|" />
+    <Asset d:Source="Project" d:ProjectName="VS.Common" Type="Microsoft.VisualStudio.MefComponent" Path="|VS.Common|" />
+    <Asset d:Source="Project" d:ProjectName="%CurrentProject%" Type="Microsoft.VisualStudio.MefComponent" Path="|%CurrentProject%|" />
+  </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/VS2022/source.extension.vsixmanifest
+++ b/VS2022/source.extension.vsixmanifest
@@ -1,42 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="0E655946-6443-4BCE-AABB-6466C14C6521" Version="4.4.12" Language="en-US" Publisher="Matthew Manela" />
-    <DisplayName>Chutzpah Test Adapter for the Test Explorer</DisplayName>
-    <Description xml:space="preserve">Chutzpah adapter for the Visual Studio Unit Test Explorer. Chutzpah is an open source JavaScript test runner which enables you to run JavaScript unit tests from the command line and from inside of Visual Studio.</Description>
-    <MoreInfo>https://github.com/mmanela/chutzpah</MoreInfo>
-    <License>EULA.rtf</License>
-    <GettingStartedGuide>https://github.com/mmanela/chutzpah</GettingStartedGuide>
-    <Icon>chetTimes.png</Icon>
-    <PreviewImage>chetTimes.png</PreviewImage>
-    <Tags>Javascript, Unit Testing, HTML, Visual Studio 2022, TDD, qunit, jasmine, testing, CoffeeScript, TypeScript</Tags>
-  </Metadata>
-  <Installation InstalledByMsi="false">
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.IntegratedShell">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0]" />
-  </Dependencies>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    <Asset d:Source="Project" d:ProjectName="%CurrentProject%.TestAdapter" Type="Microsoft.VisualStudio.MefComponent" Path="|VS2022.TestAdapter|" />
-    <Asset Type="UnitTestExtension" d:Source="Project" d:ProjectName="%CurrentProject%.TestAdapter" Path="|VS2022.TestAdapter|" />
-    <Asset d:Source="Project" d:ProjectName="VS.Common" Type="Microsoft.VisualStudio.MefComponent" Path="|VS.Common|" />
-    <Asset d:Source="Project" d:ProjectName="%CurrentProject%" Type="Microsoft.VisualStudio.MefComponent" Path="|%CurrentProject%|" />
-  </Assets>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
+    <Metadata>
+        <Identity Id="0E655946-6443-4BCE-AABB-6466C14C6521" Version="4.4.12" Language="en-US" Publisher="Matthew Manela" />
+        <DisplayName>Chutzpah Test Adapter for the Test Explorer VS2022</DisplayName>
+        <Description xml:space="preserve">Chutzpah adapter for the Visual Studio Unit Test Explorer. Chutzpah is an open source JavaScript test runner which enables you to run JavaScript unit tests from the command line and from inside of Visual Studio.</Description>
+        <MoreInfo>https://github.com/mmanela/chutzpah</MoreInfo>
+        <License>EULA.rtf</License>
+        <GettingStartedGuide>https://github.com/mmanela/chutzpah</GettingStartedGuide>
+        <Icon>chetTimes.png</Icon>
+        <PreviewImage>chetTimes.png</PreviewImage>
+        <Tags>Javascript, Unit Testing, HTML, Visual Studio 2022, TDD, qunit, jasmine, testing, CoffeeScript, TypeScript</Tags>
+    </Metadata>
+    <Installation InstalledByMsi="false">
+        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.IntegratedShell">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+        <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0]" />
+    </Dependencies>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+        <Asset d:Source="Project" d:ProjectName="%CurrentProject%.TestAdapter" Type="Microsoft.VisualStudio.MefComponent" Path="|VS2022.TestAdapter|" />
+        <Asset Type="UnitTestExtension" d:Source="Project" d:ProjectName="%CurrentProject%.TestAdapter" Path="|VS2022.TestAdapter|" />
+        <Asset d:Source="Project" d:ProjectName="VS.Common" Type="Microsoft.VisualStudio.MefComponent" Path="|VS.Common|" />
+        <Asset d:Source="Project" d:ProjectName="%CurrentProject%" Type="Microsoft.VisualStudio.MefComponent" Path="|%CurrentProject%|" />
+    </Assets>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
 </PackageManifest>

--- a/VisualStudioContextMenu/VisualStudioContextMenu.csproj
+++ b/VisualStudioContextMenu/VisualStudioContextMenu.csproj
@@ -8,6 +8,8 @@
     <GenerateVsixV3>true</GenerateVsixV3>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -33,7 +35,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CreateVsixContainer>True</CreateVsixContainer>
-    <DeployExtension>False</DeployExtension>
+    <DeployExtension>True</DeployExtension>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/VisualStudioContextMenu/source.extension.vsixmanifest
+++ b/VisualStudioContextMenu/source.extension.vsixmanifest
@@ -1,37 +1,37 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="63768A3F-B111-4075-891B-455910567C70" Version="4.4.12" Language="en-US" Publisher="Matthew Manela" />
-        <DisplayName>Chutzpah Test Runner Context Menu VS2022</DisplayName>
-        <Description>Chutzpah is an open source JavaScript test runner which helps you integrate JavaScript unit testing into your website. It enables you to run JavaScript unit tests from the command line and from inside of Visual Studio.</Description>
-        <License>EULA.rtf</License>
-        <GettingStartedGuide>https://github.com/mmanela/chutzpah</GettingStartedGuide>
-        <Icon>chetTimes.png</Icon>
-        <PreviewImage>chetTimes.png</PreviewImage>
-        <Tags>Javascript, Unit Testing, HTML, Visual Studio 2022, TDD, qunit, jasmine, testing, CoffeeScript, TypeScript</Tags>
-    </Metadata>
-    <Installation InstalledByMsi="false">
-        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
-            <ProductArchitecture>amd64</ProductArchitecture>
-        </InstallationTarget>
-        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
-            <ProductArchitecture>amd64</ProductArchitecture>
-        </InstallationTarget>
-        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
-            <ProductArchitecture>amd64</ProductArchitecture>
-        </InstallationTarget>
-        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.IntegratedShell">
-            <ProductArchitecture>amd64</ProductArchitecture>
-        </InstallationTarget>
-    </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-        <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0]" />
-    </Dependencies>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    </Assets>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
+  <Metadata>
+    <Identity Id="63768A3F-B111-4075-891B-455910567C70" Version="4.4.12" Language="en-US" Publisher="Matthew Manela" />
+    <DisplayName>Chutzpah Test Context Menu (VS2022)</DisplayName>
+    <Description>Chutzpah is an open source JavaScript test runner which helps you integrate JavaScript unit testing into your website. It enables you to run JavaScript unit tests from the command line and from inside of Visual Studio.</Description>
+    <License>EULA.rtf</License>
+    <GettingStartedGuide>https://github.com/mmanela/chutzpah</GettingStartedGuide>
+    <Icon>chetTimes.png</Icon>
+    <PreviewImage>chetTimes.png</PreviewImage>
+    <Tags>Javascript, Unit Testing, HTML, Visual Studio 2022, TDD, qunit, jasmine, testing, CoffeeScript, TypeScript</Tags>
+  </Metadata>
+  <Installation InstalledByMsi="false">
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.IntegratedShell">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0]" />
+  </Dependencies>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+  </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/VisualStudioContextMenu/source.extension.vsixmanifest
+++ b/VisualStudioContextMenu/source.extension.vsixmanifest
@@ -1,37 +1,37 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="63768A3F-B111-4075-891B-455910567C70" Version="4.4.12" Language="en-US" Publisher="Matthew Manela" />
-    <DisplayName>Chutzpah Test Runner Context Menu Extension</DisplayName>
-    <Description>Chutzpah is an open source JavaScript test runner which helps you integrate JavaScript unit testing into your website. It enables you to run JavaScript unit tests from the command line and from inside of Visual Studio.</Description>
-    <License>EULA.rtf</License>
-    <GettingStartedGuide>https://github.com/mmanela/chutzpah</GettingStartedGuide>
-    <Icon>chetTimes.png</Icon>
-    <PreviewImage>chetTimes.png</PreviewImage>
-    <Tags>Javascript, Unit Testing, HTML, Visual Studio 2022, TDD, qunit, jasmine, testing, CoffeeScript, TypeScript</Tags>
-  </Metadata>
-  <Installation InstalledByMsi="false">
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.IntegratedShell">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0]" />
-  </Dependencies>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
+    <Metadata>
+        <Identity Id="63768A3F-B111-4075-891B-455910567C70" Version="4.4.12" Language="en-US" Publisher="Matthew Manela" />
+        <DisplayName>Chutzpah Test Runner Context Menu VS2022</DisplayName>
+        <Description>Chutzpah is an open source JavaScript test runner which helps you integrate JavaScript unit testing into your website. It enables you to run JavaScript unit tests from the command line and from inside of Visual Studio.</Description>
+        <License>EULA.rtf</License>
+        <GettingStartedGuide>https://github.com/mmanela/chutzpah</GettingStartedGuide>
+        <Icon>chetTimes.png</Icon>
+        <PreviewImage>chetTimes.png</PreviewImage>
+        <Tags>Javascript, Unit Testing, HTML, Visual Studio 2022, TDD, qunit, jasmine, testing, CoffeeScript, TypeScript</Tags>
+    </Metadata>
+    <Installation InstalledByMsi="false">
+        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.IntegratedShell">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+        <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0]" />
+    </Dependencies>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
This addresses the hang when launching Debugger against ie in VS2022.
Also enabled DeployExtension for debugging.